### PR TITLE
Add __serialize/__unserialize

### DIFF
--- a/lib/Horde/Smtp.php
+++ b/lib/Horde/Smtp.php
@@ -235,6 +235,24 @@ class Horde_Smtp implements Serializable
     }
 
     /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->_params;
+    }
+
+    /**
+     * @param array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        $this->_params = $data;
+        $this->_initOb();
+    }
+
+    /**
      */
     public function __get($name)
     {


### PR DESCRIPTION
> As of PHP 8.1.0, a class which implements Serializable without also implementing [__serialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize) and [__unserialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize) will generate a deprecation warning.